### PR TITLE
[docs][radio] Fix error in code snippet

### DIFF
--- a/docs/src/app/(public)/(content)/react/components/radio/page.mdx
+++ b/docs/src/app/(public)/(content)/react/components/radio/page.mdx
@@ -55,7 +55,7 @@ To use a radio group in a form:
         <Radio.Root value="express" />
         Express
       </Field.Label>
-    <RadioGroup>
+    </RadioGroup>
   </Field.Root>
 </Form>
 ```


### PR DESCRIPTION
There was a typo in the form integration snippet for `Radio`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
